### PR TITLE
Fix that fillnanvertices() procudes an error when cdata contains nan values. 

### DIFF
--- a/hippomaps/utils.py
+++ b/hippomaps/utils.py
@@ -261,7 +261,7 @@ def density_interp(indensity, outdensity, cdata, label, method='linear'):
 
        Returns
        -------
-       interp : interpolated data
+       interp : interpolated data. Any NaN values will be interpolated.
     """
     VALID_STATUS = {'0p5mm', '1mm', '2mm', '18k', '8k', '2k', 'unfoldiso'}
     if indensity not in VALID_STATUS:


### PR DESCRIPTION
When I tried to downsample data that contained nan values I encountered an issue.
Here is an example:

```
test_array = np.random.normal(size = (7262, 768))
test_array[0, 0] = np.nan
interpolated_data = density_interp("0p5mm", "2mm", test_array, "hipp", 'linear')
```

I ran into the following issue:

```
Traceback (most recent call last):
  File "/public/home/Jaquent/research_projects/testing-hippunfold/scripts/full_pipeline/v2/utility_scripts/resample_hippocampal_gifti_files.py", line 72, in <module>
    main(data_directory, search_pattern, source_den, target_den, resources_dir)
  File "/public/home/Jaquent/research_projects/testing-hippunfold/scripts/full_pipeline/v2/utility_scripts/resample_hippocampal_gifti_files.py", line 39, in main
    HM_help.resample_hippocampal_gifti(file_path, source_den, target_den, resources_dir)
  File "/home1/Jaquent/research_projects/testing-hippunfold/scripts/utilities/hippomaps_helper_utils.py", line 311, in resample_hippocampal_gifti
    interpolated_data = density_interp(source_den, tagert_den, orig_gii, label, 'linear')
  File "/public/home/Jaquent/Toolboxes/hippomaps/hippomaps/utils.py", line 287, in density_interp
    interp = fillnanvertices(faces, interp)
  File "/public/home/Jaquent/Toolboxes/hippomaps/hippomaps/utils.py", line 236, in fillnanvertices
    if sum(np.isnan(Vold)) == sum(np.isnan(Vnew)):  # stop if no changes
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

My change seem to have fixed the issue, which seem to be related to that `sum()` doesn't return one value in some cases. 

 **Disclaimer**: please take this with some skepticism as I fixed this with LLM-help but I don't fully understand the difference between the changes myself.  

That being said, I checked the interpolated data after implementing the change with the raw data in terms of their overall distribution as well as the means/SDs for each row and I didn't notice anything obviously wrong. 
 