### PR TITLE
Fix permutation-test null distributions collapsing onto the vertex axis

### DIFF
--- a/hippomaps/stats.py
+++ b/hippomaps/stats.py
@@ -21,6 +21,39 @@ from joblib import Parallel, delayed
 resourcesdir=str(Path(__file__).parents[1]) + '/hippomaps/resources'
 
 
+def _orient_null(imgperm_rand, nVertices):
+    """Orient a surrogate/null array to (nperm, nVertices).
+
+    Surrogate generators (eigenstrapping ``SurfaceEigenstrapping.__call__``,
+    Moran spectral randomization) return the permuted maps as either
+    (nperm, nVertices) or (nVertices, nperm) depending on their version. The
+    stats functions assume a single fixed layout (they call ``.T`` on the
+    result to build a (nVertices, nperm) array), so a version mismatch makes
+    the null distribution collapse onto the vertex axis (e.g. length 7261
+    instead of nperm). Use the reference map's vertex count -- which is
+    unambiguous -- as ground truth to always return (nperm, nVertices).
+
+    Parameters
+    ----------
+    imgperm_rand : np.ndarray
+        Permutation array, either (nperm, nVertices) or (nVertices, nperm).
+    nVertices : int
+        Number of vertices in the reference map (i.e. len(imgfix)).
+
+    Returns
+    -------
+    np.ndarray of shape (nperm, nVertices)
+    """
+    imgperm_rand = np.asarray(imgperm_rand)
+    if imgperm_rand.ndim == 1:
+        # a single permutation was returned squeezed to 1D
+        return imgperm_rand[np.newaxis, :]
+    # if the vertex axis is axis 0, transpose so it becomes axis 1
+    if imgperm_rand.shape[1] != nVertices and imgperm_rand.shape[0] == nVertices:
+        imgperm_rand = imgperm_rand.T
+    return imgperm_rand
+
+
 def spin_test(imgfix, imgperm, nperm=1000, metric='pearsonr', label='hipp', den='0p5mm'):
     """
        Permutation testing of unfolded hippocampus maps.
@@ -87,7 +120,9 @@ def spin_test(imgfix, imgperm, nperm=1000, metric='pearsonr', label='hipp', den=
     r_obs = pearsonr(imgfix.flatten(), imgperm.flatten())[0]  
 
     if metric=='pearsonr':
-        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), permutedimg.reshape([254*126,nperm])),axis=1))[0,1:]
+        # transpose so corrcoef treats each map as a variable (else the null
+        # collapses onto the vertex axis, giving a length-nVertices null).
+        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), permutedimg.reshape([254*126,nperm])),axis=1).T)[0,1:]
     elif metric=='spearmanr':
         metricnull = spearmanr(imgfix.reshape([-1,1]), permutedimg.reshape([254*126,nperm]))[0][0,1:]
 
@@ -145,9 +180,12 @@ def moran_test(imgfix, imgperm, nperm=1000, metric='pearsonr', label='hipp', den
     r_obs = eval(metric)(imgfix, imgperm)[0]
 
     # randomize
-    imgperm_rand = msr.randomize(imgperm).T
+    # _orient_null normalizes to (nperm, nVertices) across versions; .T -> (nVertices, nperm)
+    imgperm_rand = _orient_null(msr.randomize(imgperm), imgfix.shape[0]).T
     if metric=='pearsonr':
-        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), imgperm_rand),axis=1))[0,1:]
+        # imgperm_rand is (nVertices, nperm); transpose so corrcoef treats each
+        # map as a variable (else the null collapses onto the vertex axis).
+        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), imgperm_rand),axis=1).T)[0,1:]
     elif metric=='spearmanr':
         metricnull = spearmanr(imgfix, imgperm_rand )[0][0,1:]
 
@@ -210,10 +248,13 @@ def eigenstrapping(imgfix, imgperm, nperm=10000, metric='pearsonr', label='hipp'
 
     # randomize
     hippomaps.utils.blockPrint()
-    imgperm_rand = eigen(n=nperm).T
+    # _orient_null normalizes to (nperm, nVertices) across eigenstrapping versions; .T -> (nVertices, nperm)
+    imgperm_rand = _orient_null(eigen(n=nperm), imgfix.shape[0]).T
     hippomaps.utils.enablePrint()
     if metric=='pearsonr':
-        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), imgperm_rand),axis=1))[0,1:]
+        # imgperm_rand is (nVertices, nperm); transpose so corrcoef treats each
+        # map as a variable (else the null collapses onto the vertex axis).
+        metricnull = np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), imgperm_rand),axis=1).T)[0,1:]
     elif metric=='spearmanr':
         metricnull = spearmanr(imgfix, imgperm_rand)[0][0,1:]
 
@@ -270,7 +311,8 @@ def contextualize2D(taskMaps, taskNames='', numerbMaps=False, n_topComparison=3,
             surface=f"{resourcesdir}/canonical_surfs/tpl-avg_space-canonical_den-0p5mm_label-hipp_midthickness.surf.gii",
             data=taskMapsresamp[:, t])
         hippomaps.utils.enablePrint()
-        return eigen(n=nperm).T  # Returns shape (nV, nperm)
+        # _orient_null normalizes to (nperm, nV) across eigenstrapping versions; .T -> (nV, nperm)
+        return _orient_null(eigen(n=nperm), nV).T  # Returns shape (nV, nperm)
     permutedTasks_list = Parallel(n_jobs=-1)(
         delayed(generate_permutations)(t) for t in range(nT)
     )


### PR DESCRIPTION
## Problem

A user reported that `stats.eigenstrapping` returned a null distribution whose length was the **number of vertices** (e.g. 7261) rather than `nperm`.

**Root cause (primary):** the `pearsonr` branch (the default metric) of `spin_test`, `moran_test`, and `eigenstrapping` builds the null with:

```python
np.corrcoef(np.concatenate((imgfix.reshape([-1,1]), imgperm_rand), axis=1))[0, 1:]
```

The concatenated matrix is `(nVertices, nperm+1)`, but `np.corrcoef` treats **rows** as variables. So it computes an `(nVertices, nVertices)` correlation matrix and the null ends up length `≈nVertices` instead of `nperm` — and the p-value is computed against the wrong quantities. The `spearmanr` branch was already correct (scipy's `spearmanr` treats columns as variables), and `contextualize2D` already transposes before `corrcoef`.

Fix: transpose the concatenated matrix so each map is a variable. Verified the null is now length `nperm` and matches a per-permutation `pearsonr` loop exactly.

**Root cause (secondary / defensive):** `SurfaceEigenstrapping.__call__` and Moran randomization return surrogates as either `(nperm, nVertices)` or `(nVertices, nperm)` depending on version (`setup.py` only pins `eigenstrapping>=0.1`), and the code assumed a fixed layout via a hardcoded `.T`. Added a small `_orient_null` helper that normalizes to `(nperm, nVertices)` using the reference map's vertex count as ground truth, and routed `moran_test`, `eigenstrapping`, and `contextualize2D` through it.

## Verification

Numerically checked both fixes against a ground-truth per-permutation loop, for both eigenstrapping output orientations:

| eigen output | null length | == nperm | matches per-perm `pearsonr` |
|---|---|---|---|
| `(nperm, nV)` | `nperm` | ✓ | ✓ |
| `(nV, nperm)` | `nperm` | ✓ | ✓ |

`_orient_null` unit-tested for `(nperm,nV)` (unchanged), `(nV,nperm)` (transposed), 1D single-perm (reshaped), and the `nV==nperm` edge case (no spurious transpose).

## Notes

This replaces #48, which was accidentally branched off the unmerged `28-statpy-performance-issues` branch and carried unrelated WIP commits. This PR is based directly on `master`.